### PR TITLE
Add preferred format selection to plugin settings

### DIFF
--- a/book_format.py
+++ b/book_format.py
@@ -9,16 +9,24 @@ class BookFormat:
     ]
     PREFERRED_FMTS = ['EPUB', 'MOBI']
 
-    def __init__(self, db, book_id):
+    def __init__(self, db, book_id, preferred_fmt=None):
         self.file_path = None
         self.fmt = None
 
         fmts = db.formats(book_id)
         if len(fmts) > 0:
             fmt = fmts[0]
-            for preferred_fmt in self.PREFERRED_FMTS:
-                if preferred_fmt in fmts:
-                    fmt = preferred_fmt
+
+            preference_list = []
+            if preferred_fmt:
+                preference_list.append(preferred_fmt)
+            for f in self.PREFERRED_FMTS:
+                if f not in preference_list:
+                    preference_list.append(f)
+
+            for pref in preference_list:
+                if pref in fmts:
+                    fmt = pref
                     break
 
             if fmt in self.SUPPORTED_FMTS:

--- a/check_worker.py
+++ b/check_worker.py
@@ -99,7 +99,7 @@ class CheckWorker(QObject):
 
             self.logger.info('File: book_id={}'.format(book_id))
 
-            book_format = BookFormat(self.db, book_id)
+            book_format = BookFormat(self.db, book_id, prefs['preferred_format'])
 
             if book_format.file_path:
                 self.books_count += 1

--- a/config.py
+++ b/config.py
@@ -4,7 +4,6 @@ __license__ = 'GPL v3'
 from PyQt5.Qt import QWidget, QHBoxLayout, QVBoxLayout, QFormLayout, QLabel, QLineEdit, QCheckBox, QComboBox
 from calibre.utils.config import JSONConfig
 from calibre.gui2 import get_current_db
-
 import sys
 if sys.version_info[0] >= 3:
     unicode = str
@@ -17,6 +16,7 @@ prefs.defaults['debug'] = True
 prefs.defaults['update_metadata'] = False
 prefs.defaults['threads'] = 2
 prefs.defaults['bookshelves_custom_column'] = ''
+prefs.defaults['preferred_format'] = ''
 
 
 class ConfigWidget(QWidget):
@@ -77,9 +77,23 @@ class ConfigWidget(QWidget):
         self.bookshelves_custom_column.setCurrentText(prefs['bookshelves_custom_column'])
         self.form.addRow('Bookshelves Column:', self.bookshelves_custom_column)
 
+        supported_fmts = [
+            'AZW', 'AZW3', 'AZW4', 'CBZ', 'CBR', 'CBC', 'CHM', 'DJVU', 'DOCX', 'EPUB', 'FB2', 'FBZ', 'HTML', 'HTMLZ',
+            'LIT', 'LRF', 'MOBI', 'ODT', 'PDF', 'PRC', 'PDB', 'PML', 'RB', 'RTF', 'SNB', 'TCR', 'TXT', 'TXTZ'
+        ]
+        self.preferred_format = QComboBox(self)
+        self.preferred_format.addItem('Auto (EPUB > MOBI)', '')
+        for fmt in supported_fmts:
+            self.preferred_format.addItem(fmt, fmt)
+        saved_fmt = prefs['preferred_format']
+        index = self.preferred_format.findData(saved_fmt)
+        self.preferred_format.setCurrentIndex(index if index >= 0 else 0)
+        self.form.addRow('Preferred Format:', self.preferred_format)
+
     def save_settings(self):
         prefs['api_key'] = unicode(self.api_key.text())
         prefs['debug'] = self.debug.isChecked()
         prefs['update_metadata'] = self.update_metadata.isChecked()
         prefs['threads'] = int(self.threads.currentText())
         prefs['bookshelves_custom_column'] = unicode(self.bookshelves_custom_column.currentText())
+        prefs['preferred_format'] = self.preferred_format.currentData()

--- a/upload_manager.py
+++ b/upload_manager.py
@@ -71,7 +71,7 @@ class UploadManager(QObject):
         book_id = self.pending_book_ids.pop()
         self.logger.info('Upload book: book_id={}; title={}'.format(book_id, self.db.get_proxy_metadata(book_id).title))
 
-        book_format = BookFormat(self.db, book_id)
+        book_format = BookFormat(self.db, book_id, prefs['preferred_format'])
 
         if book_format.file_path:
             self.started.emit(book_id)


### PR DESCRIPTION
Introduces a configurable 'Preferred Format' option in the plugin settings UI, allowing users to choose a specific eBook format (e.g. EPUB, MOBI) or keep the default auto-selection behaviour (EPUB > MOBI). The selected preference is persisted and applied when resolving the format to sync.